### PR TITLE
Added energy price area select to location page

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -73,7 +73,8 @@ export type LocationDetails = {
     defaultInsideZoneId: number,
     activeProgramId: number,
     longitude: number,
-    latitude: number
+    latitude: number,
+    energyPriceAreaId: number
 }
 
 export type ZoneDetails = { id: number, name: string, description: string, mqttTopic: string, isDefaultOutsideZone: boolean, isDefaultInsideZone: boolean, locationId: number }

--- a/src/routes/locations/[locationId=integer]/+page.svelte
+++ b/src/routes/locations/[locationId=integer]/+page.svelte
@@ -41,6 +41,13 @@
 		bind:value={data.location.defaultInsideZoneId}
 	></SelectInput>
 
+	<SelectInput
+		label="Energy Price Area"
+		placeholder="Choose the energy price area"
+		items={data.energyPriceAreas}
+		bind:value={data.location.energyPriceAreaId}
+	></SelectInput>
+
 	<GeoLocationInput
 		bind:longitude={data.location.longitude}
 		bind:latitude={data.location.latitude}

--- a/src/routes/locations/[locationId=integer]/+page.ts
+++ b/src/routes/locations/[locationId=integer]/+page.ts
@@ -1,6 +1,6 @@
 import { Get } from '$lib/api';
 import { baseUrl } from '$lib/environment';
-import type { ZoneInfo } from '$lib/models';
+import type { EnergyPriceAreaInfo, ZoneInfo } from '$lib/models';
 import type { PageLoad } from './$types';
 
 export const load = (async (loadEvent) => {
@@ -8,7 +8,11 @@ export const load = (async (loadEvent) => {
     const { fetch: svelteFetch } = loadEvent;
     const { params } = loadEvent;
 
-    const zoneInfos = await Get<ZoneInfo[]>(svelteFetch, `${baseUrl}api/locations/${params.locationId}/zones`);
+    const [zoneInfos, energyPriceAreaInfos] = await Promise.all([
+        Get<ZoneInfo[]>(svelteFetch, `${baseUrl}api/locations/${params.locationId}/zones`),
+        Get<EnergyPriceAreaInfo[]>(svelteFetch, `${baseUrl}api/energy-price-areas`)
+    ]);
     const zones = zoneInfos.map((zone) => ({ value: zone.id, name: zone.name }));
-    return { zones: zones }
+    const energyPriceAreas = energyPriceAreaInfos.map((area) => ({ value: area.id, name: area.name }));
+    return { zones, energyPriceAreas }
 }) satisfies PageLoad;


### PR DESCRIPTION
## Summary
- Added `energyPriceAreaId` field to `LocationDetails` type in `models.ts`
- Fetches energy price areas from `api/energy-price-areas` in parallel with zones on page load
- Added a `SelectInput` for choosing the energy price area on the location edit page

## Test plan
- [ ] Navigate to a location edit page and verify the Energy Price Area dropdown appears
- [ ] Confirm the dropdown is populated with areas from the API
- [ ] Select an area, save, and verify the selection is persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)