### PR TITLE
Add gradient fill to energy cost chart bars

### DIFF
--- a/src/components/EnergyCostChart.svelte
+++ b/src/components/EnergyCostChart.svelte
@@ -99,8 +99,18 @@
 			position: 'top'
 		},
 		dataLabels: { enabled: false },
+		fill: {
+			type: 'gradient',
+			gradient: {
+				shade: 'light',
+				type: 'vertical',
+				shadeIntensity: 0.4,
+				opacityFrom: 1,
+				opacityTo: 0.6
+			}
+		},
 		plotOptions: {
-			bar: { columnWidth: '80%' }
+			bar: { columnWidth: '80%', borderRadius: 3 }
 		}
 	};
 </script>


### PR DESCRIPTION
## Summary

- Added vertical gradient fill to the bar chart in the Energy Costs page
- Bars fade from full opacity at the top to 60% at the bottom for a cleaner look
- Added subtle rounded corners to the bars

## Test plan

- [ ] Navigate to `/energy-costs`, select a location and time period
- [ ] Verify bars render with gradient fill and rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)