### PR TITLE
Add Energy Calculation Strategy and Smart Meter Sensor to location edit

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -65,6 +65,11 @@ export type ZoneReading = {
     updated: Date
 }
 
+export enum EnergyCalculationStrategy {
+    SmartMeter = 1,
+    Sensors = 2
+}
+
 export type LocationDetails = {
     id: number,
     name: string,
@@ -76,7 +81,9 @@ export type LocationDetails = {
     latitude: number,
     energyPriceAreaId: number,
     fixedEnergyPrice: number,
-    useFixedEnergyPrice: boolean
+    useFixedEnergyPrice: boolean,
+    energyCalculationStrategy: EnergyCalculationStrategy,
+    smartMeterSensorId: number
 }
 
 export type ZoneDetails = { id: number, name: string, description: string, mqttTopic: string, isDefaultOutsideZone: boolean, isDefaultInsideZone: boolean, locationId: number }

--- a/src/routes/locations/[locationId=integer]/+page.svelte
+++ b/src/routes/locations/[locationId=integer]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import { deleteLocation, updateLocation } from '$lib/api';
+	import { EnergyCalculationStrategy } from '$lib/models';
 	import {
 		Grid,
 		TextInput,
@@ -66,6 +67,22 @@
 		label="Fixed Energy Price"
 		bind:value={data.location.fixedEnergyPrice}
 	/>
+
+	<SelectInput
+		label="Energy Calculation Strategy"
+		items={[{ value: 1, name: 'Smart Meter' }, { value: 2, name: 'Sensors' }]}
+		bind:value={data.location.energyCalculationStrategy}
+	/>
+
+	{#if data.location.energyCalculationStrategy === EnergyCalculationStrategy.SmartMeter}
+		<SelectInput
+			label="Smart Meter Sensor"
+			placeholder="Choose the smart meter sensor"
+			items={data.sensors}
+			bind:value={data.location.smartMeterSensorId}
+			required
+		/>
+	{/if}
 
 	<SaveButton on:click={async () => await handleUpdateLocation()} />
 

--- a/src/routes/locations/[locationId=integer]/+page.ts
+++ b/src/routes/locations/[locationId=integer]/+page.ts
@@ -1,6 +1,6 @@
 import { Get } from '$lib/api';
 import { baseUrl } from '$lib/environment';
-import type { EnergyPriceAreaInfo, ZoneInfo } from '$lib/models';
+import type { EnergyPriceAreaInfo, SensorInfo, ZoneInfo } from '$lib/models';
 import type { PageLoad } from './$types';
 
 export const load = (async (loadEvent) => {
@@ -8,11 +8,13 @@ export const load = (async (loadEvent) => {
     const { fetch: svelteFetch } = loadEvent;
     const { params } = loadEvent;
 
-    const [zoneInfos, energyPriceAreaInfos] = await Promise.all([
+    const [zoneInfos, energyPriceAreaInfos, sensorInfos] = await Promise.all([
         Get<ZoneInfo[]>(svelteFetch, `${baseUrl}api/locations/${params.locationId}/zones`),
-        Get<EnergyPriceAreaInfo[]>(svelteFetch, `${baseUrl}api/energy-price-areas`)
+        Get<EnergyPriceAreaInfo[]>(svelteFetch, `${baseUrl}api/energy-price-areas`),
+        Get<SensorInfo[]>(svelteFetch, `${baseUrl}api/energy-costs/sensors?locationId=${params.locationId}`)
     ]);
     const zones = zoneInfos.map((zone) => ({ value: zone.id, name: zone.name }));
     const energyPriceAreas = energyPriceAreaInfos.map((area) => ({ value: area.id, name: area.name }));
-    return { zones, energyPriceAreas }
+    const sensors = sensorInfos.map((sensor) => ({ value: sensor.id, name: sensor.name }));
+    return { zones, energyPriceAreas, sensors }
 }) satisfies PageLoad;


### PR DESCRIPTION
## Summary

- Added `EnergyCalculationStrategy` enum (`SmartMeter = 1`, `Sensors = 2`) to `models.ts`
- Added `energyCalculationStrategy` and `smartMeterSensorId` fields to `LocationDetails` type
- Location edit page now fetches available sensors from `api/energy-costs/sensors?locationId=...`
- Added Energy Calculation Strategy select input to the location edit form
- Smart Meter Sensor select is only shown when the strategy is set to "Smart Meter"

## Test plan

- [ ] Open an existing location for editing
- [ ] Verify the Energy Calculation Strategy select appears with Smart Meter and Sensors options
- [ ] Select "Smart Meter" — Smart Meter Sensor select should appear, populated with sensors for this location
- [ ] Select "Sensors" — Smart Meter Sensor select should be hidden
- [ ] Save the location and verify changes persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)