### PR TITLE
Improve about page with server version

### DIFF
--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,7 +1,36 @@
 <script lang="ts">
-	import { Heading } from 'flowbite-svelte';
+	import { onMount } from 'svelte';
+	import { Card } from 'flowbite-svelte';
+	import { baseUrl } from '$lib/environment';
 
 	const gitTag = import.meta.env.VITE_GIT_TAG;
+	let serverVersion: string | null = null;
+
+	onMount(async () => {
+		const response = await fetch(`${baseUrl}api/version`);
+		if (response.ok) {
+			const data: { value: string } = await response.json();
+			serverVersion = data.value;
+		}
+	});
 </script>
 
-<Heading tag="h3" class="text-center">Version {gitTag}</Heading>
+<div class="flex justify-center pt-16">
+	<Card class="w-full max-w-sm text-center">
+		<div class="mb-6">
+			<h1 class="text-3xl font-bold text-blue-500">HeatKeeper</h1>
+	</div>
+		<div class="divide-y divide-gray-200 dark:divide-gray-700">
+			<div class="py-3">
+				<p class="text-xs uppercase tracking-widest text-gray-500 dark:text-gray-400">Client</p>
+				<p class="mt-1 font-mono text-lg font-semibold text-gray-800 dark:text-white">{gitTag}</p>
+			</div>
+			<div class="py-3">
+				<p class="text-xs uppercase tracking-widest text-gray-500 dark:text-gray-400">Server</p>
+				<p class="mt-1 font-mono text-lg font-semibold text-gray-800 dark:text-white">
+					{serverVersion ?? '…'}
+				</p>
+			</div>
+		</div>
+	</Card>
+</div>


### PR DESCRIPTION
## Summary
- Fetches and displays the server version from `api/version` alongside the client version
- Redesigned as a centered card with the app name, monospace version strings, and a divider between client and server rows

## Test plan
- [ ] Navigate to the about page and verify both client and server versions are displayed
- [ ] Verify the `…` placeholder shows briefly while the server version loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)