### PR TITLE
Add energy consumers page with live SSE updates

### DIFF
--- a/src/components/EnergyConsumers.svelte
+++ b/src/components/EnergyConsumers.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { baseUrl } from '$lib/environment';
+	import { createSseStore } from '$lib/stores/sse';
+	import type { EnergyConsumer } from '$lib/models';
+	import { Badge, Checkbox, Label } from 'flowbite-svelte';
+
+	export let locationId: number;
+
+	let showAll = false;
+
+	function buildUrl(showAll: boolean) {
+		return `${baseUrl}api/locations/${locationId}/energy-consumers?showAll=${showAll}`;
+	}
+
+	let energyStore = createSseStore<EnergyConsumer[]>(buildUrl(false));
+
+	function onShowAllChange() {
+		energyStore.close();
+		energyStore = createSseStore<EnergyConsumer[]>(buildUrl(showAll));
+	}
+
+	onDestroy(() => energyStore.close());
+
+	function formatPower(watts: number): string {
+		if (watts >= 1000) {
+			return (watts / 1000).toFixed(2) + ' kW';
+		}
+		return watts.toFixed(0) + ' W';
+	}
+
+	function formatUpdated(updated: string): string {
+		return new Date(updated).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+	}
+
+	const statusColor = (status: string) => {
+		switch (status) {
+			case 'open': return 'green';
+			case 'connecting': return 'yellow';
+			case 'error': return 'red';
+			default: return 'dark';
+		}
+	};
+</script>
+
+<div class="flex flex-wrap items-center gap-3 mb-4">
+	<h2 class="text-xl font-semibold">Energy Consumers</h2>
+	<Badge color={statusColor($energyStore.status)}>{$energyStore.status}</Badge>
+	{#if $energyStore.lastUpdated}
+		<span class="text-sm text-gray-500">{$energyStore.lastUpdated.toLocaleTimeString()}</span>
+	{/if}
+</div>
+
+<div class="flex items-center gap-2 mb-4">
+	<Checkbox id="showAll" bind:checked={showAll} on:change={onShowAllChange} />
+	<Label for="showAll">Show all (including inactive)</Label>
+</div>
+
+{#if $energyStore.status === 'connecting' && !$energyStore.data}
+	<p class="text-sm text-gray-500">Connecting...</p>
+{:else if $energyStore.status === 'error' && !$energyStore.data}
+	<p class="text-sm text-red-600">{$energyStore.error ?? 'Connection error'}</p>
+{:else}
+	{@const consumers = ($energyStore.data ?? []).slice().sort((a, b) => b.activePowerImport - a.activePowerImport)}
+	<div class="flex flex-col gap-2">
+		{#each consumers as consumer (consumer.sensorId)}
+			<div class="rounded-lg border border-gray-700 bg-gray-800 px-4 py-3">
+				<div class="font-medium text-white truncate">{consumer.sensorName}</div>
+				<div class="flex items-center justify-between mt-1">
+					<span class="font-mono text-lg text-white">{formatPower(consumer.activePowerImport)}</span>
+					<span class="text-sm text-gray-400">{formatUpdated(consumer.updated)}</span>
+				</div>
+			</div>
+		{:else}
+			<p class="text-sm text-gray-500">No consumers found</p>
+		{/each}
+	</div>
+
+	{#if consumers.length > 0}
+		{@const total = consumers.reduce((sum, c) => sum + c.activePowerImport, 0)}
+		<div class="mt-4 rounded-lg border border-gray-600 bg-gray-700 px-4 py-3">
+			<div class="font-medium text-gray-300">Total</div>
+			<div class="mt-1">
+				<span class="font-mono text-lg text-white">{formatPower(total)}</span>
+			</div>
+		</div>
+	{/if}
+{/if}

--- a/src/lib/components.ts
+++ b/src/lib/components.ts
@@ -18,3 +18,4 @@ export { default as ConditionGroup } from '../components/ConditionGroup.svelte';
 export { default as WindDirection } from '../components/WindDirection.svelte';
 export { default as CheckboxInput } from '../components/CheckboxInput.svelte';
 export { default as EnergyCostChart } from '../components/EnergyCostChart.svelte';
+export { default as EnergyConsumers } from '../components/EnergyConsumers.svelte';

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -493,3 +493,10 @@ export type EnergyCost = {
     resolution: Resolution,
     timeSeries: EnergyCostEntry[]
 }
+
+export type EnergyConsumer = {
+    sensorId: number,
+    sensorName: string,
+    activePowerImport: number,
+    updated: string
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -27,6 +27,7 @@
 			<NavLi href="/triggers">Triggers</NavLi>
 			<NavLi href="/scheduled-jobs">Scheduled Jobs</NavLi>
 			<NavLi href="/energy-costs">Energy Costs</NavLi>
+			<NavLi href="/energy-consumers">Energy Consumers</NavLi>
 			<NavLi href="/mqtt-client">MQTT Client</NavLi>
 			<NavLi href="/login">Login</NavLi>
 		</NavUl>

--- a/src/routes/energy-consumers/+page.svelte
+++ b/src/routes/energy-consumers/+page.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import { EnergyConsumers, SelectInput } from '$lib/components';
+
+	export let data: PageData;
+
+	let selectedLocationId: number | null = data.locations[0]?.id ?? null;
+
+	$: locationItems = data.locations.map((l) => ({ value: l.id, name: l.name }));
+</script>
+
+<svelte:head>
+	<title>Energy Consumers</title>
+</svelte:head>
+
+<h1 class="text-2xl font-semibold mb-6">Energy Consumers</h1>
+
+<div class="mb-6 max-w-sm">
+	<SelectInput
+		label="Location"
+		items={locationItems}
+		bind:value={selectedLocationId}
+		placeholder="Select a location"
+	/>
+</div>
+
+{#key selectedLocationId}
+	{#if selectedLocationId}
+		<EnergyConsumers locationId={selectedLocationId} />
+	{/if}
+{/key}

--- a/src/routes/energy-consumers/+page.ts
+++ b/src/routes/energy-consumers/+page.ts
@@ -1,0 +1,12 @@
+import { baseUrl } from '$lib/environment';
+import type { LocationInfo } from '$lib/models';
+import type { PageLoad } from './$types';
+
+export const load = (async ({ fetch }) => {
+	const response = await fetch(`${baseUrl}api/locations`, {
+		credentials: 'include',
+		headers: { 'Content-Type': 'application/json' }
+	});
+	const locations = await response.json() as LocationInfo[];
+	return { locations };
+}) satisfies PageLoad;

--- a/src/routes/energy-consumers/[locationId=integer]/+page.svelte
+++ b/src/routes/energy-consumers/[locationId=integer]/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import { EnergyConsumers } from '$lib/components';
+
+	export let data: PageData;
+</script>
+
+<svelte:head>
+	<title>Energy Consumers</title>
+</svelte:head>
+
+<EnergyConsumers locationId={data.locationId} />

--- a/src/routes/energy-consumers/[locationId=integer]/+page.ts
+++ b/src/routes/energy-consumers/[locationId=integer]/+page.ts
@@ -1,0 +1,5 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = ({ params }) => {
+	return { locationId: parseInt(params.locationId) };
+};


### PR DESCRIPTION
## Summary

- Adds `/energy-consumers` route with location selector (defaults to first location) and a reusable `EnergyConsumers` component
- Component connects to `api/locations/{locationId}/energy-consumers` via SSE for live updates
- Displays consumers as mobile-friendly cards sorted by active power (highest first), with a total consumption summary below
- Checkbox to toggle showing inactive consumers (`showAll`)
- Nav bar link added

## Test plan

- [x] Navigate to Energy Consumers in the nav bar
- [x] Verify the first location is selected by default and consumers load immediately
- [x] Switch locations and verify the list updates
- [x] Toggle "Show all" and verify inactive consumers appear/disappear
- [x] Verify cards update in real time as SSE events arrive
- [x] Verify total matches the sum of visible consumers
- [x] Check layout on mobile screen widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)