### PR TITLE
Fix x-axis timezone handling for energy and temperature charts

### DIFF
--- a/src/components/EnergyCostChart.svelte
+++ b/src/components/EnergyCostChart.svelte
@@ -29,16 +29,20 @@
 	const isHourly = resolution === Resolution.Hourly;
 	const displaySeries = isHourly ? aggregatePairs(timeSeries) : timeSeries;
 
+	function parseUtcTimestamp(value: string): Date {
+		return new Date(value.endsWith('Z') || value.includes('+') ? value : value + 'Z');
+	}
+
 	function formatTimestamp(value: string): string {
-		const date = new Date(value);
+		const date = parseUtcTimestamp(value);
 		if (isHourly) {
 			return date.getHours().toString();
 		} else if (resolution === Resolution.Daily) {
 			return displaySeries.length > 7
-				? date.getDate().toString()
-				: date.toLocaleDateString('en-GB', { weekday: 'short' });
+				? date.getUTCDate().toString()
+				: date.toLocaleDateString('en-GB', { weekday: 'short', timeZone: 'UTC' });
 		} else {
-			return date.toLocaleDateString('en-GB', { month: 'short' });
+			return date.toLocaleDateString('en-GB', { month: 'short', timeZone: 'UTC' });
 		}
 	}
 

--- a/src/components/EnergyPriceChart.svelte
+++ b/src/components/EnergyPriceChart.svelte
@@ -51,7 +51,9 @@
 			tickAmount: 10,
 			labels: {
 				formatter: function (value) {
-					return new Date(value).getHours().toString();
+					const s = String(value);
+					const d = new Date(s.endsWith('Z') || s.includes('+') ? s : s + 'Z');
+					return d.getHours().toString();
 				},
 				hideOverlappingLabels: false
 			}

--- a/src/routes/zone-insights/[zoneId=integer]/+page.svelte
+++ b/src/routes/zone-insights/[zoneId=integer]/+page.svelte
@@ -55,16 +55,20 @@
 		const timeSeries = data.temperatures.timeSeries;
 		const isHourly = resolution === Resolution.Hourly;
 
+		function parseUtcTimestamp(value: string): Date {
+			return new Date(value.endsWith('Z') || value.includes('+') ? value : value + 'Z');
+		}
+
 		function formatTimestamp(value: string): string {
-			const date = new Date(value);
+			const date = parseUtcTimestamp(value);
 			if (isHourly) {
 				return date.getHours().toString();
 			} else if (resolution === Resolution.Daily) {
 				return timeSeries.length > 7
-					? date.getDate().toString()
-					: date.toLocaleDateString('en-GB', { weekday: 'short' });
+					? date.getUTCDate().toString()
+					: date.toLocaleDateString('en-GB', { weekday: 'short', timeZone: 'UTC' });
 			} else {
-				return date.toLocaleDateString('en-GB', { month: 'short' });
+				return date.toLocaleDateString('en-GB', { month: 'short', timeZone: 'UTC' });
 			}
 		}
 


### PR DESCRIPTION
## Summary
- UTC timestamps from the API arrive without a `Z` suffix, causing `new Date()` to parse them as local time
- This made x-axis hour labels show UTC hours (e.g. 20, 21, 22, 23, 0…) instead of local hours starting at 0
- Fixed by appending `Z` before parsing so timestamps are correctly interpreted as UTC, then displaying in local time via `getHours()`

## Affected components
- `EnergyCostChart.svelte`
- `EnergyPriceChart.svelte`
- `zone-insights/+page.svelte`

## Test plan
- [ ] View zone insights for today — hourly x-axis should start at 0
- [ ] View energy cost chart — hourly x-axis should start at 0
- [ ] View energy price chart — hourly x-axis should start at 0
- [ ] Verify daily and monthly resolutions still display correct labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)